### PR TITLE
update install setup instructions

### DIFF
--- a/readme.org
+++ b/readme.org
@@ -17,7 +17,7 @@
 
 **** For this script to work you're gonna need to:
 
-     - add /resources/cred.gpg (it should be encrypted with your default GPG key)
+     - add /resources/creds.gpg (it should be encrypted with your default GPG key)
        in the following format:
 
        #+begin_src clojure
@@ -33,9 +33,9 @@
 
 **** then you can run:
      #+begin_src sh
-       npm
+       npm install
        # or:
-       yarn
+       yarn install
      #+end_src
      when it's done installing npm packages:
      #+begin_src sh


### PR DESCRIPTION
- cred is called creds in source code
- adding install for [npm](https://docs.npmjs.com/cli/install) and [yarn](https://classic.yarnpkg.com/en/docs/cli/install/#toc-yarn-install)

I also noticed that my gpg installation is called `gpg` rather than `gpg2`, but not sure if that's common enough to add some instructions about aliasing `gpg2` to `gpg`